### PR TITLE
/info: use discord interaction choices

### DIFF
--- a/main.py
+++ b/main.py
@@ -187,7 +187,7 @@ async def metar(interaction: Interaction, airport: str, decode: bool = False):
     app_commands.Choice(name="Lima Kilo - Flashpoint Levant - EU", value="lkeu"),
     app_commands.Choice(name="Lima Kilo - Flashpoint Levant - NA", value="lkna") 
 ])
-async def info(interaction: Interaction, name: str, details: str = 'all'):
+async def info(interaction: Interaction, name: app_commands.Choice[str], details: str = 'all'):
     """
     Gets player count info for designated servers
     Args:

--- a/main.py
+++ b/main.py
@@ -191,7 +191,7 @@ async def info(interaction: Interaction, name: app_commands.Choice[str], details
     """
     Gets player count info for designated servers
     Args:
-        name | str | Name of server
+        name | Choice[str] | Name of server
         *sub_cats | tuple | List of wanted statistics, blank sends all
     """
     name = name.lower()  # Save the code of a .lower() on every instance of name and details

--- a/main.py
+++ b/main.py
@@ -194,7 +194,7 @@ async def info(interaction: Interaction, name: app_commands.Choice[str], details
         name | Choice[str] | Name of server
         *sub_cats | tuple | List of wanted statistics, blank sends all
     """
-    name = name.lower()  # Save the code of a .lower() on every instance of name and details
+    name = name.value  # take the actual string value from the input Choice
     details = details.lower()
 
     try:

--- a/main.py
+++ b/main.py
@@ -180,6 +180,13 @@ async def metar(interaction: Interaction, airport: str, decode: bool = False):
 
 
 @app_commands.command()
+@app_commands.describe(name="DCS server selection")
+@app_commands.choices(name=[
+    app_commands.Choice(name="Hoggit - Georgia At War", value="gaw"),
+    app_commands.Choice(name="Hoggit - Persian Gulf At War", value="pgaw"),
+    app_commands.Choice(name="Lima Kilo - Flashpoint Levant - EU", value="lkeu"),
+    app_commands.Choice(name="Lima Kilo - Flashpoint Levant - NA", value="lkna") 
+])
 async def info(interaction: Interaction, name: str, details: str = 'all'):
     """
     Gets player count info for designated servers


### PR DESCRIPTION
**When merged, this pull request will:**
- change the /info command to provide a list of server names to choose from

- [x] Has this change been tested? 
_(@QuantifyGG has agreed to test this)_

