### PR TITLE
tweak: Use member.mention in strips' message

### DIFF
--- a/tb_discord/tb_events.py
+++ b/tb_discord/tb_events.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from discord import File
+from discord import File, AllowedMentions
 from discord.errors import NotFound
 from os import remove
 from pathlib import Path
@@ -79,5 +79,5 @@ async def on_member_join(member):
     d.text((646, 57), "M/" + strip_text["aircraft"], font=font, fill=(0, 0, 0), anchor="lm")
     strip.save(fp="strip.png")
     await bot.get_channel(1099805424934469652).send(f"Welcome to Digital Controllers, "
-                                                    f"{member.name}!", file=File("strip.png"))
+                                                    f"{member.mention}!", file=File("strip.png"), allowedmentions=AllowedMentions.none())
     remove("strip.png")


### PR DESCRIPTION
When merged, this PR will:

* Replace the user's name in the welcome message to use a mention instead (allowing easy inspection of the user)
* Not ping the user

